### PR TITLE
feat(api): Define initial database schema for notes

### DIFF
--- a/apps/api/app/models/note.rb
+++ b/apps/api/app/models/note.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class Note < ApplicationRecord
+  enum :status, {
+    private: 'private',
+    public: 'public',
+    archived: 'archived'
+  }, default: :private
+
+  validates :slug, presence: true
+  validates :status, presence: true
+end

--- a/apps/api/db/migrate/20260113000001_create_notes.rb
+++ b/apps/api/db/migrate/20260113000001_create_notes.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class CreateNotes < ActiveRecord::Migration[8.0]
+  def change
+    enable_extension 'pgcrypto' unless extension_enabled?('pgcrypto')
+
+    create_table :notes, id: :uuid do |t|
+      t.uuid   :user_id, null: false
+      t.string :title,   null: false, default: ''
+      t.text   :body,    null: false, default: ''
+      t.string :slug,    null: false
+      t.string :status,  null: false, default: 'private'
+
+      t.timestamps
+    end
+
+    add_index :notes, :user_id
+    add_index :notes, :slug
+    add_index :notes, :status
+  end
+end

--- a/apps/api/db/schema.rb
+++ b/apps/api/db/schema.rb
@@ -1,0 +1,30 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[8.1].define(version: 2026_01_13_000001) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "pg_catalog.plpgsql"
+  enable_extension "pgcrypto"
+
+  create_table "notes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.text "body", default: "", null: false
+    t.datetime "created_at", null: false
+    t.string "slug", null: false
+    t.string "status", default: "private", null: false
+    t.string "title", default: "", null: false
+    t.datetime "updated_at", null: false
+    t.uuid "user_id", null: false
+    t.index ["slug"], name: "index_notes_on_slug"
+    t.index ["status"], name: "index_notes_on_status"
+    t.index ["user_id"], name: "index_notes_on_user_id"
+  end
+end


### PR DESCRIPTION
## Summary

Add the initial `notes` table migration and model as the foundation for the note-taking feature.

### Changes

- Create `notes` table with UUID primary key
- Add columns: `user_id`, `title`, `body`, `slug`, `status`
- Add indexes on `user_id`, `slug`, `status`
- Define `Note` model with status enum (`private`, `public`, `archived`)

## Notes

- `user_id` is included without a foreign key constraint; the constraint will be added when the `users` table is created
- `deleted` status was intentionally omitted — permanent deletion uses physical deletion per the design in `docs/product/note-organization.md`
- Full-text search optimization is out of scope for this PR

## Related Issue

Closes #3