### PR TITLE
chore: add Makefile for common dev commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+.PHONY: bash bundle console migrate credentials help
+
+bash:
+	docker compose exec api bash
+
+bundle:
+	docker compose exec api bundle install
+
+console:
+	docker compose exec api bin/rails console
+
+migrate:
+	docker compose exec api bin/rails db:migrate
+
+credentials:
+	docker compose exec -e EDITOR=vim api bin/rails credentials:edit
+
+help:
+	@echo "Usage: make [target]"
+	@echo ""
+	@echo "  bash          Open bash in API container"
+	@echo "  bundle        Install gems"
+	@echo "  console       Open Rails console"
+	@echo "  migrate       Run database migrations"
+	@echo "  credentials   Edit Rails credentials"


### PR DESCRIPTION
## Summary

Add a Makefile to simplify commonly used Docker Compose commands for local development.

Available commands:
- `make bash` - Open bash in API container
- `make bundle` - Install gems
- `make console` - Open Rails console
- `make migrate` - Run database migrations
- `make credentials` - Edit Rails credentials

## Notes

This reduces typing for repetitive commands like `docker compose exec api ...`.

Run `make help` to see all available targets.