### PR TITLE
chore(infra): split CI workflow into parallel jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,44 @@ defaults:
     working-directory: apps/api
 
 jobs:
-  rails:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version-file: apps/api/.ruby-version
+          bundler-cache: true
+          working-directory: apps/api
+
+      - name: Run Rubocop
+        run: bin/rubocop
+
+  security:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version-file: apps/api/.ruby-version
+          bundler-cache: true
+          working-directory: apps/api
+
+      - name: Run Brakeman
+        run: bin/brakeman --quiet --no-pager --exit-on-warn --exit-on-error
+
+      - name: Run Bundler Audit
+        run: bin/bundler-audit --update
+
+  test:
     runs-on: ubuntu-latest
 
     env:
@@ -56,15 +93,6 @@ jobs:
 
       - name: Boot check
         run: bin/rails runner "puts 'Rails boot OK'"
-
-      - name: Run Rubocop
-        run: bin/rubocop
-
-      - name: Run Brakeman
-        run: bin/brakeman --quiet --no-pager --exit-on-warn --exit-on-error
-
-      - name: Run Bundler Audit
-        run: bin/bundler-audit --update
 
       - name: Run RSpec
         run: bundle exec rspec


### PR DESCRIPTION
## Summary

Split the monolithic `rails` CI job into three independent parallel jobs for faster feedback and clearer failure diagnosis:

- **lint**: Rubocop (no DB required)
- **security**: Brakeman, Bundler Audit (no DB required)
- **test**: RSpec with PostgreSQL + pg_bigm

## Notes

- All three jobs run in parallel without dependencies
- `lint` and `security` jobs are significantly faster as they skip database setup
- PostgreSQL with pg_bigm custom image is only built for the `test` job
- Ruby setup with `bundler-cache: true` is shared across all jobs

## Related Issue

Closes #26