### PR TITLE
Integrate Markdown editor into note editing

### DIFF
--- a/apps/web/src/app/(authenticated)/notes/[uuid]/page.tsx
+++ b/apps/web/src/app/(authenticated)/notes/[uuid]/page.tsx
@@ -4,6 +4,7 @@ import { useState, useCallback, useMemo } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { getNote, updateNote, deleteNote, type Note } from "@/lib/api";
+import { VditorEditor } from "@/components/editor";
 
 export default function NoteEditorPage() {
   const params = useParams();
@@ -99,7 +100,7 @@ function NoteEditor({ note }: { note: Note }) {
   }, [deleteMutation]);
 
   return (
-    <div className="max-w-[900px] mx-auto px-12 sm:px-24 pt-12 pb-32 h-full flex flex-col">
+    <div className="max-w-[900px] mx-auto px-12 sm:px-24 pt-12 h-full flex flex-col">
       {/* Header with actions */}
       <div className="flex items-center justify-between mb-6">
         <div className="text-sm text-[var(--workspace-text-secondary)]">
@@ -140,13 +141,15 @@ function NoteEditor({ note }: { note: Note }) {
         className="w-full text-4xl font-bold bg-transparent border-none outline-none text-[var(--workspace-text-primary)] placeholder:text-[var(--workspace-text-tertiary)] mb-6"
       />
 
-      {/* Body textarea */}
-      <textarea
-        value={body}
-        onChange={(e) => setBody(e.target.value)}
-        placeholder="Start writing..."
-        className="flex-1 w-full bg-transparent border-none outline-none resize-none text-[var(--workspace-text-primary)] placeholder:text-[var(--workspace-text-tertiary)] leading-relaxed"
-      />
+      {/* Body editor */}
+      <div className="flex-1 min-h-0">
+        <VditorEditor
+          value={body}
+          onChange={setBody}
+          placeholder="Start writing..."
+          className="note-editor"
+        />
+      </div>
 
       {/* Error display */}
       {updateMutation.isError && (

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -222,6 +222,33 @@
   font-size: 14px;
 }
 
+/* Vditor: Note editor full height */
+.note-editor,
+.note-editor .vditor {
+  height: 100% !important;
+}
+
+.note-editor .vditor-content {
+  height: calc(100% - 37px) !important;
+  /* Subtract toolbar height */
+}
+
+/* Vditor: Match workspace theme */
+.note-editor .vditor {
+  border: none !important;
+  background: transparent !important;
+}
+
+.note-editor .vditor-toolbar {
+  background: var(--workspace-bg) !important;
+  border-bottom: 1px solid var(--workspace-border) !important;
+  padding: 0 !important;
+}
+
+.note-editor .vditor-ir {
+  background: transparent !important;
+}
+
 /* Vditor: Force Japanese font to prevent Chinese glyphs */
 .vditor,
 .vditor *,

--- a/apps/web/src/components/editor/vditor-editor.tsx
+++ b/apps/web/src/components/editor/vditor-editor.tsx
@@ -89,6 +89,7 @@ export function VditorEditor({
         minHeight: typeof height === "number" ? height : 300,
         theme: "dark",
         icon: "ant",
+        lang: "en_US",
         toolbar: [
           "headings",
           "bold",


### PR DESCRIPTION
## Summary
- Replace simple textarea with Vditor Markdown editor in note editing page
- Add full-height CSS styling for the editor to fill available space
- Set English locale for toolbar tooltips

<img width="2884" height="1262" alt="CleanShot 2026-01-15 at 19 33 27@2x" src="https://github.com/user-attachments/assets/36de2ae4-028c-4b4b-9422-896efca60a0a" />

## Notes
- Uses existing VditorEditor component from PoC (Issue #34)
- Editor supports IR (Instant Rendering) mode for Typora-like experience
- Change detection (`hasChanges`) works correctly with the new editor

## Related Issue
Closes #35