### PR TITLE
Remove slug from notes - use UUID only

### DIFF
--- a/apps/api/app/controllers/notes_controller.rb
+++ b/apps/api/app/controllers/notes_controller.rb
@@ -58,7 +58,6 @@ class NotesController < ApplicationController
       id: note.id,
       title: note.title,
       body: note.body,
-      slug: note.slug,
       status: note.status,
       created_at: note.created_at,
       updated_at: note.updated_at

--- a/apps/api/app/models/note.rb
+++ b/apps/api/app/models/note.rb
@@ -9,10 +9,7 @@ class Note < ApplicationRecord
     archived: 'archived'
   }, default: :personal
 
-  validates :slug, presence: true
   validates :status, presence: true
-
-  before_validation :generate_slug, on: :create
 
   # Full-text search using pg_bigm
   # Searches title and body with ILIKE for case-insensitive matching
@@ -22,17 +19,4 @@ class Note < ApplicationRecord
     sanitized = "%#{sanitize_sql_like(query)}%"
     where('title ILIKE :q OR body ILIKE :q', q: sanitized)
   }
-
-  private
-
-  def generate_slug
-    return if slug.present?
-
-    self.slug = if title.present?
-                  parameterized = title.parameterize
-                  parameterized.presence || SecureRandom.alphanumeric(12)
-    else
-                  SecureRandom.alphanumeric(12)
-    end
-  end
 end

--- a/apps/api/db/migrate/20260115222937_remove_slug_from_notes.rb
+++ b/apps/api/db/migrate/20260115222937_remove_slug_from_notes.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class RemoveSlugFromNotes < ActiveRecord::Migration[8.1]
+  def change
+    remove_index :notes, :slug
+    remove_column :notes, :slug, :string, null: false
+  end
+end

--- a/apps/api/db/schema.rb
+++ b/apps/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_01_14_100000) do
+ActiveRecord::Schema[8.1].define(version: 2026_01_15_222937) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_bigm"
   enable_extension "pg_catalog.plpgsql"
@@ -19,13 +19,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_01_14_100000) do
   create_table "notes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.text "body", default: "", null: false
     t.datetime "created_at", null: false
-    t.string "slug", null: false
     t.string "status", default: "personal", null: false
     t.string "title", default: "", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
     t.index [ "body" ], name: "index_notes_on_body_bigm", opclass: :gin_bigm_ops, using: :gin
-    t.index [ "slug" ], name: "index_notes_on_slug"
     t.index [ "status" ], name: "index_notes_on_status"
     t.index [ "title" ], name: "index_notes_on_title_bigm", opclass: :gin_bigm_ops, using: :gin
     t.index [ "user_id" ], name: "index_notes_on_user_id"

--- a/apps/api/spec/models/note_spec.rb
+++ b/apps/api/spec/models/note_spec.rb
@@ -91,31 +91,4 @@ RSpec.describe Note do
       end
     end
   end
-
-  describe 'slug generation' do
-    let(:user) { create(:user) }
-
-    context 'when title is present' do
-      it 'generates slug from title' do
-        note = create(:note, user: user, title: 'My Test Note')
-        expect(note.slug).to eq('my-test-note')
-      end
-    end
-
-    context 'when title is blank' do
-      it 'generates random slug' do
-        note = create(:note, user: user, title: '')
-        expect(note.slug).to be_present
-        expect(note.slug.length).to eq(12)
-      end
-    end
-
-    context 'when title contains only non-ASCII characters' do
-      it 'generates random slug for Japanese-only title' do
-        note = create(:note, user: user, title: '日本語タイトル')
-        expect(note.slug).to be_present
-        expect(note.slug.length).to eq(12)
-      end
-    end
-  end
 end

--- a/apps/api/spec/requests/notes_spec.rb
+++ b/apps/api/spec/requests/notes_spec.rb
@@ -14,12 +14,11 @@ RSpec.describe 'Notes API', type: :request do
         id: { type: :string, format: :uuid },
         title: { type: :string, nullable: true },
         body: { type: :string, nullable: true },
-        slug: { type: :string },
         status: { type: :string, enum: %w[personal published archived] },
         created_at: { type: :string, format: 'date-time' },
         updated_at: { type: :string, format: 'date-time' }
       },
-      required: %w[id slug status created_at updated_at]
+      required: %w[id status created_at updated_at]
     }
   end
 
@@ -48,12 +47,11 @@ RSpec.describe 'Notes API', type: :request do
                   id: { type: :string, format: :uuid },
                   title: { type: :string, nullable: true },
                   body: { type: :string, nullable: true },
-                  slug: { type: :string },
                   status: { type: :string, enum: %w[personal published archived] },
                   created_at: { type: :string, format: 'date-time' },
                   updated_at: { type: :string, format: 'date-time' }
                 },
-                required: %w[id slug status created_at updated_at]
+                required: %w[id status created_at updated_at]
               }
             }
           },
@@ -121,12 +119,11 @@ RSpec.describe 'Notes API', type: :request do
                 id: { type: :string, format: :uuid },
                 title: { type: :string, nullable: true },
                 body: { type: :string, nullable: true },
-                slug: { type: :string },
                 status: { type: :string, enum: %w[personal published archived] },
                 created_at: { type: :string, format: 'date-time' },
                 updated_at: { type: :string, format: 'date-time' }
               },
-              required: %w[id slug status created_at updated_at]
+              required: %w[id status created_at updated_at]
             }
           },
           required: %w[note]
@@ -136,14 +133,16 @@ RSpec.describe 'Notes API', type: :request do
         run_test!
       end
 
-      response '201', 'note created without title (generates random slug)' do
+      response '201', 'note created without title' do
         schema type: :object,
           properties: {
             note: {
               type: :object,
               properties: {
                 id: { type: :string, format: :uuid },
-                slug: { type: :string }
+                title: { type: :string, nullable: true },
+                body: { type: :string, nullable: true },
+                status: { type: :string, enum: %w[personal published archived] }
               }
             }
           }
@@ -190,12 +189,11 @@ RSpec.describe 'Notes API', type: :request do
                 id: { type: :string, format: :uuid },
                 title: { type: :string, nullable: true },
                 body: { type: :string, nullable: true },
-                slug: { type: :string },
                 status: { type: :string, enum: %w[personal published archived] },
                 created_at: { type: :string, format: 'date-time' },
                 updated_at: { type: :string, format: 'date-time' }
               },
-              required: %w[id slug status created_at updated_at]
+              required: %w[id status created_at updated_at]
             }
           },
           required: %w[note]
@@ -265,12 +263,11 @@ RSpec.describe 'Notes API', type: :request do
                 id: { type: :string, format: :uuid },
                 title: { type: :string, nullable: true },
                 body: { type: :string, nullable: true },
-                slug: { type: :string },
                 status: { type: :string, enum: %w[personal published archived] },
                 created_at: { type: :string, format: 'date-time' },
                 updated_at: { type: :string, format: 'date-time' }
               },
-              required: %w[id slug status created_at updated_at]
+              required: %w[id status created_at updated_at]
             }
           },
           required: %w[note]

--- a/apps/api/swagger/swagger.yaml
+++ b/apps/api/swagger/swagger.yaml
@@ -208,8 +208,6 @@ paths:
                         body:
                           type: string
                           nullable: true
-                        slug:
-                          type: string
                         status:
                           type: string
                           enum:
@@ -224,7 +222,6 @@ paths:
                           format: date-time
                       required:
                       - id
-                      - slug
                       - status
                       - created_at
                       - updated_at
@@ -246,7 +243,7 @@ paths:
       parameters: []
       responses:
         '201':
-          description: note created without title (generates random slug)
+          description: note created without title
           content:
             application/json:
               schema:

--- a/apps/web/src/lib/api/notes.ts
+++ b/apps/web/src/lib/api/notes.ts
@@ -5,7 +5,6 @@ export interface Note {
   id: string; // UUID
   title: string;
   body: string;
-  slug: string;
   status: "personal" | "published" | "archived";
   created_at: string;
   updated_at: string;

--- a/docs/adr/0011-no-slug-for-notes.md
+++ b/docs/adr/0011-no-slug-for-notes.md
@@ -1,0 +1,60 @@
+# 0011 No Slug for Notes - Use UUID Only
+
+Date: 2026-01-15
+
+## Status
+
+Accepted
+
+## Context
+
+Issue #14 proposed implementing automatic slug generation for notes to provide URL-friendly identifiers. Slugs are typically used for:
+
+- SEO optimization (search engines can infer content from URLs)
+- Human-readable URLs for sharing
+- Memorable URLs for direct access
+
+However, after analysis, we determined that slugs are not necessary for this application:
+
+1. **Personal notes don't need SEO** - The primary use case is personal note-taking (`status: personal`), which doesn't benefit from search engine optimization.
+
+2. **UUID is sufficient for identification** - UUIDs provide globally unique, collision-free identifiers without additional logic for handling duplicates.
+
+3. **Many successful apps use UUID-only URLs** - Notion, Google Docs, and Figma all use opaque IDs rather than slugs.
+
+4. **Slug implementation adds complexity** - Duplicate handling (suffixes like `-1`, `-2`), format validation, and scope decisions (user-level vs global uniqueness) add unnecessary code.
+
+5. **Future flexibility** - If published notes require slugs later, they can be added specifically for that feature when requirements are clearer.
+
+## Decision
+
+Remove the `slug` column from the `notes` table and use only UUID for note identification.
+
+## Alternatives Considered
+
+1. **Implement slugs as planned** - Would add SEO-friendly URLs but increases implementation complexity for unclear benefit.
+
+2. **Optional slugs for published notes only** - More targeted approach, but published note requirements are not yet defined.
+
+3. **Hybrid approach (UUID + slug)** - Keep both identifiers, but this adds redundancy without clear use case.
+
+## Consequences
+
+### Benefits
+
+- Simpler codebase with less validation logic
+- No edge cases for duplicate slug handling
+- Faster note creation (no slug generation)
+- Cleaner API responses
+
+### Trade-offs
+
+- URLs are not human-readable (`/notes/550e8400-...` vs `/notes/my-note`)
+- If published notes need SEO-friendly URLs in the future, slug support will need to be re-implemented
+- Slightly harder to identify notes from URLs alone
+
+### Migration
+
+- Remove `slug` column and associated index
+- Remove slug generation logic from `Note` model
+- Update API responses and tests


### PR DESCRIPTION
## Summary

- Remove `slug` column from `notes` table
- Simplify Note model by removing slug generation logic
- Add ADR documenting the decision to use UUID-only identification

## Notes

After analyzing Issue #14 (slug generation), we determined that slugs are unnecessary for this application:

- Personal notes don't benefit from SEO-friendly URLs
- UUID provides sufficient uniqueness without duplicate handling complexity
- Many successful apps (Notion, Google Docs, Figma) use opaque IDs

If published notes require SEO-friendly URLs in the future, slug support can be re-implemented with clearer requirements.

### Changes
- Migration: Remove `slug` column and index
- Model: Remove `validates :slug`, `before_validation :generate_slug`, and `generate_slug` method
- Controller: Remove `slug` from API response
- Frontend: Remove `slug` from Note type
- Tests: Remove slug-related test cases
- Swagger: Update API schema

## Related Issue

Closes #14