### PR TITLE
Add note favoriting feature

### DIFF
--- a/apps/api/app/controllers/notes_controller.rb
+++ b/apps/api/app/controllers/notes_controller.rb
@@ -68,7 +68,7 @@ class NotesController < ApplicationController
   private
 
   def note_params
-    params.fetch(:note, {}).permit(:title, :body, :status, :parent_note_id, attachment_ids: [])
+    params.fetch(:note, {}).permit(:title, :body, :status, :parent_note_id, :favorited_at, attachment_ids: [])
   end
 
   def note_attributes
@@ -91,6 +91,7 @@ class NotesController < ApplicationController
       status: note.status,
       effective_status: note.effective_status,
       parent_note_id: note.parent_note_id,
+      favorited_at: note.favorited_at,
       attachments: note.attachments.map { |attachment| attachment_response(attachment) },
       created_at: note.created_at,
       updated_at: note.updated_at

--- a/apps/api/app/models/note.rb
+++ b/apps/api/app/models/note.rb
@@ -32,6 +32,8 @@ class Note < ApplicationRecord
   validate :parent_must_not_have_parent
   validate :parent_must_belong_to_same_user
 
+  before_save :clear_favorite_on_archive
+
   # Returns the effective status considering parent inheritance
   # - If self is archived, return archived (child can be independently archived)
   # - If parent exists, inherit parent's effective_status
@@ -73,6 +75,10 @@ class Note < ApplicationRecord
         errors.add(:attachments, "must be less than #{MAX_FILE_SIZE / 1.megabyte}MB")
       end
     end
+  end
+
+  def clear_favorite_on_archive
+    self.favorited_at = nil if status_changed? && archived?
   end
 
   # Full-text search using pg_bigm

--- a/apps/api/db/migrate/20260119000000_add_favorited_at_to_notes.rb
+++ b/apps/api/db/migrate/20260119000000_add_favorited_at_to_notes.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddFavoritedAtToNotes < ActiveRecord::Migration[8.0]
+  def change
+    add_column :notes, :favorited_at, :datetime, null: true
+  end
+end

--- a/apps/api/db/schema.rb
+++ b/apps/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_01_18_200000) do
+ActiveRecord::Schema[8.1].define(version: 2026_01_19_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_bigm"
   enable_extension "pg_catalog.plpgsql"
@@ -47,6 +47,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_01_18_200000) do
   create_table "notes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.text "body", default: "", null: false
     t.datetime "created_at", null: false
+    t.datetime "favorited_at"
     t.uuid "parent_note_id"
     t.string "status", default: "personal", null: false
     t.string "title", default: "", null: false

--- a/apps/api/swagger/swagger.yaml
+++ b/apps/api/swagger/swagger.yaml
@@ -215,7 +215,7 @@ paths:
                           - personal
                           - published
                           - archived
-                        images:
+                        attachments:
                           type: array
                         created_at:
                           type: string
@@ -226,7 +226,7 @@ paths:
                       required:
                       - id
                       - status
-                      - images
+                      - attachments
                       - created_at
                       - updated_at
                 required:
@@ -271,7 +271,7 @@ paths:
                         - personal
                         - published
                         - archived
-                      images:
+                      attachments:
                         type: array
                       created_at:
                         type: string
@@ -282,7 +282,7 @@ paths:
                     required:
                     - id
                     - status
-                    - images
+                    - attachments
                     - created_at
                     - updated_at
                 required:
@@ -321,7 +321,7 @@ paths:
                       - published
                       - archived
                       example: personal
-                    image_ids:
+                    attachment_ids:
                       type: array
                       items:
                         type: string
@@ -370,7 +370,7 @@ paths:
                         - personal
                         - published
                         - archived
-                      images:
+                      attachments:
                         type: array
                       created_at:
                         type: string
@@ -381,7 +381,7 @@ paths:
                     required:
                     - id
                     - status
-                    - images
+                    - attachments
                     - created_at
                     - updated_at
                 required:
@@ -432,7 +432,7 @@ paths:
                         - personal
                         - published
                         - archived
-                      images:
+                      attachments:
                         type: array
                       created_at:
                         type: string
@@ -443,7 +443,7 @@ paths:
                     required:
                     - id
                     - status
-                    - images
+                    - attachments
                     - created_at
                     - updated_at
                 required:
@@ -485,7 +485,7 @@ paths:
                       - personal
                       - published
                       - archived
-                    image_ids:
+                    attachment_ids:
                       type: array
                       items:
                         type: string
@@ -506,6 +506,35 @@ paths:
           description: unauthorized
         '404':
           description: note not found
+  "/notes/{note_id}/attachments/{signed_id}":
+    parameters:
+    - name: note_id
+      in: path
+      format: uuid
+      description: Note ID
+      required: true
+      schema:
+        type: string
+    - name: signed_id
+      in: path
+      description: Attachment signed ID
+      required: true
+      schema:
+        type: string
+    delete:
+      summary: Detach an attachment from a note
+      tags:
+      - Notes
+      description: Removes an attached file from a note
+      security:
+      - bearer_auth: []
+      responses:
+        '204':
+          description: attachment detached
+        '401':
+          description: unauthorized
+        '404':
+          description: note belongs to another user
   "/p/{id}":
     parameters:
     - name: id

--- a/apps/web/src/components/app-header.tsx
+++ b/apps/web/src/components/app-header.tsx
@@ -97,6 +97,22 @@ export function AppHeader({ sidebarOpen, onToggleSidebar }: AppHeaderProps) {
     },
   });
 
+  // Favorite toggle mutation
+  const favoriteMutation = useMutation({
+    mutationFn: (favorited: boolean) =>
+      updateNote(noteId!, { favorited_at: favorited ? new Date().toISOString() : null }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["note", noteId] });
+      queryClient.invalidateQueries({ queryKey: ["notes"] });
+    },
+  });
+
+  const isFavorited = !!note?.favorited_at;
+
+  function handleToggleFavorite() {
+    favoriteMutation.mutate(!isFavorited);
+  }
+
   async function handleLogout() {
     setIsLoggingOut(true);
     try {
@@ -205,14 +221,21 @@ export function AppHeader({ sidebarOpen, onToggleSidebar }: AppHeaderProps) {
               Edited {formatRelativeTime(note.updated_at)}
             </span>
 
-            {/* Star button (placeholder) */}
-            <button
-              type="button"
-              className="p-1 hover:bg-[var(--workspace-hover)] rounded transition-colors"
-              title="Add to favorites"
-            >
-              <Star size={16} />
-            </button>
+            {/* Star button - toggle favorite (not available for archived notes) */}
+            {note.effective_status !== "archived" && (
+              <button
+                type="button"
+                onClick={handleToggleFavorite}
+                disabled={favoriteMutation.isPending}
+                className="p-1 hover:bg-[var(--workspace-hover)] rounded transition-colors disabled:opacity-50"
+                title={isFavorited ? "Remove from favorites" : "Add to favorites"}
+              >
+                <Star
+                  size={16}
+                  className={isFavorited ? "fill-yellow-500 text-yellow-500" : ""}
+                />
+              </button>
+            )}
 
             {/* More options */}
             <DropdownMenu>

--- a/apps/web/src/lib/api/notes.ts
+++ b/apps/web/src/lib/api/notes.ts
@@ -20,6 +20,7 @@ export interface Note {
   status: "personal" | "published" | "archived";
   effective_status: "personal" | "published" | "archived";
   parent_note_id: string | null;
+  favorited_at: string | null;
   attachments: NoteAttachment[];
   created_at: string;
   updated_at: string;
@@ -38,6 +39,7 @@ export interface UpdateNoteInput {
   body?: string;
   status?: Note["status"];
   parent_note_id?: string | null;
+  favorited_at?: string | null;
   attachment_ids?: string[]; // blob signed_ids to attach
 }
 


### PR DESCRIPTION
## Summary

Allow users to mark notes as favorites for quick access. Favorited notes appear at the top of each sidebar section (Private/Public), sorted by creation date.

Key changes:
- Add `favorited_at` timestamp column to notes table
- Auto-clear favorite when note is archived
- Add favorite toggle in header star icon and sidebar three-dot menu
- Display star indicator on favorited notes in sidebar

## Notes

- Parent and child notes can be favorited independently
- Favorited notes within a section are sorted by `created_at` descending (not by `favorited_at`)
- Archived notes cannot be favorited; archiving a note automatically removes it from favorites

## Related Issue

Closes #61 