### PR TITLE
Improve markdown styles for public note pages

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -313,3 +313,225 @@
   background: #252525 !important;
   font-weight: normal !important;
 }
+
+/* =====================================================
+   Public Note Page - Zenn-inspired styles
+   ===================================================== */
+
+.znc {
+  font-size: 1rem;
+  line-height: 1.8;
+  color: #333;
+}
+
+/* Headings */
+.znc h1 {
+  font-size: 1.7em;
+  font-weight: 700;
+  margin: 2.4em 0 0.8em;
+  line-height: 1.3;
+}
+
+.znc h2 {
+  font-size: 1.5em;
+  font-weight: 700;
+  margin: 2.2em 0 0.8em;
+  padding-bottom: 0.4em;
+  border-bottom: 1px solid #e5e7eb;
+  line-height: 1.3;
+}
+
+.znc h3 {
+  font-size: 1.25em;
+  font-weight: 700;
+  margin: 1.8em 0 0.6em;
+  line-height: 1.4;
+}
+
+.znc h4 {
+  font-size: 1.1em;
+  font-weight: 700;
+  margin: 1.5em 0 0.5em;
+  line-height: 1.4;
+}
+
+.znc h5,
+.znc h6 {
+  font-size: 1em;
+  font-weight: 700;
+  margin: 1.3em 0 0.4em;
+  line-height: 1.4;
+}
+
+/* Paragraphs */
+.znc p {
+  margin: 1.5em 0;
+}
+
+.znc p:first-child {
+  margin-top: 0;
+}
+
+/* Links */
+.znc a {
+  color: #0f83fd;
+  text-decoration: none;
+}
+
+.znc a:hover {
+  text-decoration: underline;
+}
+
+/* Lists */
+.znc ul,
+.znc ol {
+  margin: 1em 0;
+  padding-left: 1.5em;
+}
+
+.znc ul {
+  list-style-type: disc;
+}
+
+.znc ol {
+  list-style-type: decimal;
+}
+
+.znc li {
+  margin: 0.4em 0;
+  line-height: 1.7;
+}
+
+.znc li>ul,
+.znc li>ol {
+  margin: 0.3em 0;
+}
+
+/* Task lists (checkboxes) */
+.znc ul:has(input[type="checkbox"]) {
+  list-style: none;
+  padding-left: 0;
+}
+
+.znc li:has(> input[type="checkbox"]) {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5em;
+}
+
+.znc input[type="checkbox"] {
+  margin-top: 0.35em;
+  width: 1em;
+  height: 1em;
+  accent-color: #0f83fd;
+}
+
+/* Blockquote */
+.znc blockquote {
+  margin: 1.5em 0;
+  padding: 0.8em 1em;
+  border-left: 4px solid #e5e7eb;
+  background: #f9fafb;
+  color: #6b7280;
+}
+
+.znc blockquote p {
+  margin: 0.5em 0;
+}
+
+.znc blockquote p:first-child {
+  margin-top: 0;
+}
+
+.znc blockquote p:last-child {
+  margin-bottom: 0;
+}
+
+/* Code blocks */
+.znc pre {
+  margin: 1.5em 0;
+  padding: 1em 1.2em;
+  background-color: #1e1e1e;
+  border: 1px solid #0d1117;
+  border-radius: 0.5rem;
+  overflow-x: auto;
+  font-size: 0.875em;
+  line-height: 1.6;
+}
+
+.znc pre code {
+  background: transparent;
+  padding: 0;
+  font-size: inherit;
+  color: #e1e4e8;
+}
+
+/* Inline code */
+.znc code {
+  font-family: "SF Mono", "Fira Code", "Consolas", "Menlo", monospace;
+  font-size: 0.875em;
+  background: #eff1f3;
+  padding: 0.15em 0.4em;
+  border-radius: 0.25rem;
+  color: #1f2328;
+}
+
+/* Tables */
+.znc table {
+  border-collapse: collapse;
+  width: 100%;
+  margin: 1.5em 0;
+  font-size: 0.95em;
+}
+
+.znc th,
+.znc td {
+  border: 1px solid #e5e7eb;
+  padding: 0.7em 1em;
+  text-align: left;
+}
+
+.znc th {
+  background: #f9fafb;
+  font-weight: 600;
+}
+
+.znc tbody tr:hover {
+  background: #fafafa;
+}
+
+/* Horizontal rule */
+.znc hr {
+  margin: 2.5em 0;
+  border: 0;
+  border-top: 1px solid #e5e7eb;
+}
+
+/* Images */
+.znc img {
+  max-width: 100%;
+  height: auto;
+  border-radius: 0.375rem;
+  margin: 1.5em 0;
+}
+
+/* Strong and emphasis */
+.znc strong {
+  font-weight: 700;
+}
+
+.znc em {
+  font-style: italic;
+}
+
+/* Strikethrough */
+.znc del {
+  text-decoration: line-through;
+  color: #9ca3af;
+}
+
+/* Override highlight.js github-dark theme adjustments */
+.znc .hljs {
+  background: #1e1e1e;
+  color: #e1e4e8;
+}

--- a/apps/web/src/app/p/[uuid]/page.tsx
+++ b/apps/web/src/app/p/[uuid]/page.tsx
@@ -99,7 +99,7 @@ export default async function PublicNotePage({ params }: PageProps) {
 
         {/* Content */}
         <main>
-          <MarkdownViewer content={note.body || ""} />
+          <MarkdownViewer content={note.body || ""} variant="public" />
         </main>
 
         {/* Footer */}

--- a/apps/web/src/components/markdown-viewer.tsx
+++ b/apps/web/src/components/markdown-viewer.tsx
@@ -3,16 +3,27 @@
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeHighlight from "rehype-highlight";
-import "highlight.js/styles/github.css";
+import "highlight.js/styles/github-dark.css";
 
 interface MarkdownViewerProps {
   content: string;
   className?: string;
+  /** Use Zenn-inspired styles for public pages */
+  variant?: "default" | "public";
 }
 
-export function MarkdownViewer({ content, className }: MarkdownViewerProps) {
+export function MarkdownViewer({
+  content,
+  className,
+  variant = "default",
+}: MarkdownViewerProps) {
+  const baseClassName =
+    variant === "public"
+      ? "znc"
+      : "prose prose-slate max-w-none";
+
   return (
-    <article className={`prose prose-slate max-w-none ${className ?? ""}`}>
+    <article className={`${baseClassName} ${className ?? ""}`}>
       <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>
         {content}
       </ReactMarkdown>


### PR DESCRIPTION
## Summary

Add custom markdown rendering styles for public note pages (`/p/[uuid]`) inspired by popular tech blog platforms. This improves readability with better typography, dark-themed code blocks, and consistent styling across all markdown elements.

## Notes

- Created `.znc` class with dedicated styles for public pages
- Switched highlight.js theme from `github` to `github-dark`
- Added `variant` prop to `MarkdownViewer` component (`"default"` | `"public"`)
- Styled elements: headings, paragraphs, lists, code blocks, inline code, blockquotes, tables, horizontal rules, images, and task lists

## Related Issue

Closes #47 