### PR TITLE
Add CloudFront distribution for API HTTPS

### DIFF
--- a/apps/api/config/initializers/cors.rb
+++ b/apps/api/config/initializers/cors.rb
@@ -9,7 +9,8 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
     origins 'http://localhost:3001',
             /\Ahttps:\/\/shuriken-note.*\.vercel\.app\z/, # Vercel preview deployments
-            'https://shuriken-note.vercel.app'            # Vercel production
+            'https://shuriken-note.vercel.app',           # Vercel production
+            /\Ahttps:\/\/[a-z0-9]+\.cloudfront\.net\z/    # CloudFront distributions
 
     resource '*',
       headers: :any,

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -74,17 +74,31 @@ output "s3_bucket_regional_domain_name" {
 }
 
 # -----------------------------------------------------------------------------
-# CloudFront
+# CloudFront (Storage)
 # -----------------------------------------------------------------------------
 
-output "cloudfront_distribution_id" {
-  description = "CloudFront distribution ID"
+output "cloudfront_storage_distribution_id" {
+  description = "CloudFront distribution ID for S3 storage"
   value       = aws_cloudfront_distribution.storage.id
 }
 
-output "cloudfront_domain_name" {
-  description = "CloudFront domain name (use this for file URLs)"
+output "cloudfront_storage_domain_name" {
+  description = "CloudFront domain name for file URLs"
   value       = aws_cloudfront_distribution.storage.domain_name
+}
+
+# -----------------------------------------------------------------------------
+# CloudFront (API)
+# -----------------------------------------------------------------------------
+
+output "cloudfront_api_distribution_id" {
+  description = "CloudFront distribution ID for API HTTPS"
+  value       = aws_cloudfront_distribution.api.id
+}
+
+output "cloudfront_api_domain_name" {
+  description = "CloudFront domain name for API (use this as NEXT_PUBLIC_API_URL)"
+  value       = "https://${aws_cloudfront_distribution.api.domain_name}"
 }
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Add CloudFront distribution in front of ALB to enable HTTPS access to the API, resolving Mixed Content issues when calling API from Vercel-hosted frontend.

## Notes

- CloudFront URL: `https://db6gckhejc59w.cloudfront.net`
- Cache is disabled (TTL=0) for API requests to ensure real-time responses
- All HTTP methods and necessary headers (Authorization, Origin, etc.) are forwarded
- CORS updated to allow `*.cloudfront.net` domains
- Storage CloudFront outputs renamed for clarity (`cloudfront_storage_*`)

**Manual steps completed:**
- Vercel `NEXT_PUBLIC_API_URL` updated to CloudFront URL
- Frontend redeployed and verified working

## Related Issue

Closes #74