### PR TITLE
Configure Active Storage to use S3 with CloudFront CDN

### DIFF
--- a/apps/api/app/controllers/concerns/cloudfront_url.rb
+++ b/apps/api/app/controllers/concerns/cloudfront_url.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# Generates CloudFront CDN URLs for Active Storage attachments in production.
+# Falls back to Rails URL helpers in development/test environments.
+#
+# Usage:
+#   include CloudfrontUrl
+#   cdn_url_for(attachment)
+#
+module CloudfrontUrl
+  extend ActiveSupport::Concern
+
+  included do
+    include Rails.application.routes.url_helpers
+  end
+
+  # Returns the CDN URL for an attachment when CLOUDFRONT_HOST is configured,
+  # otherwise falls back to the standard Rails URL helper.
+  #
+  # @param attachment [ActiveStorage::Attachment, ActiveStorage::Blob] the attachment or blob
+  # @return [String, nil] the URL or nil if attachment is blank
+  def cdn_url_for(attachment)
+    return nil if attachment.blank?
+
+    blob = attachment.is_a?(ActiveStorage::Attachment) ? attachment.blob : attachment
+
+    if ENV['CLOUDFRONT_HOST'].present?
+      "https://#{ENV['CLOUDFRONT_HOST']}/#{blob.key}"
+    else
+      url_for(attachment)
+    end
+  end
+end

--- a/apps/api/app/controllers/notes_controller.rb
+++ b/apps/api/app/controllers/notes_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class NotesController < ApplicationController
-  include Rails.application.routes.url_helpers
+  include CloudfrontUrl
 
   before_action :authenticate!
 
@@ -105,7 +105,7 @@ class NotesController < ApplicationController
       filename: attachment.filename.to_s,
       content_type: attachment.content_type,
       byte_size: attachment.byte_size,
-      url: url_for(attachment)
+      url: cdn_url_for(attachment)
     }
   end
 

--- a/apps/api/config/environments/production.rb
+++ b/apps/api/config/environments/production.rb
@@ -18,8 +18,8 @@ Rails.application.configure do
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = "http://assets.example.com"
 
-  # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :local
+  # Store uploaded files on S3 with CloudFront CDN (see config/storage.yml for options).
+  config.active_storage.service = :amazon
 
   # Assume all access to the app is happening through a SSL-terminating reverse proxy.
   # config.assume_ssl = true

--- a/apps/api/config/storage.yml
+++ b/apps/api/config/storage.yml
@@ -6,22 +6,12 @@ local:
   service: Disk
   root: <%= Rails.root.join("storage") %>
 
-# Use bin/rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
-# amazon:
-#   service: S3
-#   access_key_id: <%= Rails.application.credentials.dig(:aws, :access_key_id) %>
-#   secret_access_key: <%= Rails.application.credentials.dig(:aws, :secret_access_key) %>
-#   region: us-east-1
-#   bucket: your_own_bucket-<%= Rails.env %>
-
-# Remember not to checkin your GCS keyfile to a repository
-# google:
-#   service: GCS
-#   project: your_project
-#   credentials: <%= Rails.root.join("path/to/gcs.keyfile") %>
-#   bucket: your_own_bucket-<%= Rails.env %>
-
-# mirror:
-#   service: Mirror
-#   primary: local
-#   mirrors: [ amazon, google, microsoft ]
+# Production: S3 with CloudFront CDN
+# Authentication uses IAM Role (ECS Task Role) - no access keys needed
+amazon:
+  service: S3
+  bucket: <%= ENV.fetch('S3_BUCKET_NAME', 'shuriken-note-storage-production') %>
+  region: <%= ENV.fetch('AWS_REGION', 'ap-northeast-1') %>
+  public: true
+  upload:
+    cache_control: "public, max-age=31536000"

--- a/apps/api/spec/controllers/concerns/cloudfront_url_spec.rb
+++ b/apps/api/spec/controllers/concerns/cloudfront_url_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CloudfrontUrl do
+  let(:test_class) do
+    Class.new do
+      include CloudfrontUrl
+
+      # Mock url_for for testing fallback behavior
+      def url_for(attachment)
+        blob = attachment.respond_to?(:blob) ? attachment.blob : attachment
+        "http://localhost/rails/active_storage/#{blob.key}"
+      end
+    end
+  end
+
+  let(:instance) { test_class.new }
+  let(:blob_key) { 'abc123def456' }
+
+  # Create mock objects that properly respond to type checks
+  let(:blob) do
+    double('Blob', key: blob_key).tap do |b|
+      allow(b).to receive(:is_a?).with(ActiveStorage::Attachment).and_return(false)
+    end
+  end
+
+  let(:attachment) do
+    double('Attachment', blob: blob).tap do |a|
+      allow(a).to receive(:is_a?).with(ActiveStorage::Attachment).and_return(true)
+    end
+  end
+
+  describe '#cdn_url_for' do
+    context 'when CLOUDFRONT_HOST is set' do
+      before do
+        stub_const('ENV', ENV.to_h.merge('CLOUDFRONT_HOST' => 'd123456.cloudfront.net'))
+      end
+
+      it 'returns CloudFront URL for an attachment' do
+        url = instance.cdn_url_for(attachment)
+        expect(url).to eq("https://d123456.cloudfront.net/#{blob_key}")
+      end
+
+      it 'returns CloudFront URL for a blob' do
+        url = instance.cdn_url_for(blob)
+        expect(url).to eq("https://d123456.cloudfront.net/#{blob_key}")
+      end
+    end
+
+    context 'when CLOUDFRONT_HOST is not set' do
+      before do
+        stub_const('ENV', ENV.to_h.except('CLOUDFRONT_HOST'))
+      end
+
+      it 'falls back to Rails URL helper' do
+        url = instance.cdn_url_for(attachment)
+        expect(url).to include('localhost')
+        expect(url).to include(blob_key)
+      end
+    end
+
+    context 'with nil attachment' do
+      it 'returns nil' do
+        expect(instance.cdn_url_for(nil)).to be_nil
+      end
+    end
+
+    context 'with blank attachment' do
+      it 'returns nil for empty string' do
+        expect(instance.cdn_url_for('')).to be_nil
+      end
+    end
+  end
+end

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -259,6 +259,18 @@ resource "aws_ecs_task_definition" "api" {
         {
           name  = "RAILS_LOG_TO_STDOUT"
           value = "true"
+        },
+        {
+          name  = "AWS_REGION"
+          value = var.aws_region
+        },
+        {
+          name  = "S3_BUCKET_NAME"
+          value = aws_s3_bucket.storage.id
+        },
+        {
+          name  = "CLOUDFRONT_HOST"
+          value = aws_cloudfront_distribution.storage.domain_name
         }
       ]
 


### PR DESCRIPTION
## Summary

- Configure Rails Active Storage to use AWS S3 for file storage in production
- Add CloudFront CDN integration for secure HTTPS file delivery
- Add `CloudfrontUrl` concern to generate CDN URLs for attachments
- Update ECS task definition with required environment variables

## Notes

- Authentication uses IAM Role (ECS Task Role) - no access keys needed
- Files are uploaded directly to S3 via Direct Upload (presigned URLs)
- File URLs are served through CloudFront (`d1dnvitqqygobe.cloudfront.net`)
- Local development continues to use disk storage

### Files changed
- `config/storage.yml` - Added amazon (S3) service definition
- `config/environments/production.rb` - Switched to `:amazon` storage service
- `app/controllers/concerns/cloudfront_url.rb` - New concern for CDN URL generation
- `app/controllers/notes_controller.rb` - Use `cdn_url_for` for attachment URLs
- `infra/terraform/main.tf` - Added `AWS_REGION`, `S3_BUCKET_NAME`, `CLOUDFRONT_HOST` env vars

## Related Issue

Closes #73