### PR TITLE
Add aws-sdk-s3 gem for Active Storage S3 service

### DIFF
--- a/apps/api/Gemfile
+++ b/apps/api/Gemfile
@@ -35,6 +35,9 @@ gem 'thruster', require: false
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 gem 'image_processing', '~> 1.2'
 
+# AWS S3 for Active Storage in production
+gem 'aws-sdk-s3', require: false
+
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin Ajax possible
 gem 'rack-cors'
 

--- a/apps/api/Gemfile.lock
+++ b/apps/api/Gemfile.lock
@@ -78,6 +78,25 @@ GEM
     addressable (2.8.8)
       public_suffix (>= 2.0.2, < 8.0)
     ast (2.4.3)
+    aws-eventstream (1.4.0)
+    aws-partitions (1.1209.0)
+    aws-sdk-core (3.241.4)
+      aws-eventstream (~> 1, >= 1.3.0)
+      aws-partitions (~> 1, >= 1.992.0)
+      aws-sigv4 (~> 1.9)
+      base64
+      bigdecimal
+      jmespath (~> 1, >= 1.6.1)
+      logger
+    aws-sdk-kms (1.121.0)
+      aws-sdk-core (~> 3, >= 3.241.4)
+      aws-sigv4 (~> 1.5)
+    aws-sdk-s3 (1.212.0)
+      aws-sdk-core (~> 3, >= 3.241.4)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.5)
+    aws-sigv4 (1.12.1)
+      aws-eventstream (~> 1, >= 1.0.2)
     base64 (0.3.0)
     bcrypt (3.1.21)
     bcrypt_pbkdf (1.1.2)
@@ -137,6 +156,7 @@ GEM
       pp (>= 0.6.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
+    jmespath (1.6.2)
     json (2.18.0)
     json-schema (6.1.0)
       addressable (~> 2.8)
@@ -398,6 +418,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  aws-sdk-s3
   bcrypt (~> 3.1.7)
   bootsnap
   brakeman


### PR DESCRIPTION
## Summary

Add missing `aws-sdk-s3` gem required for Active Storage to work with S3 in production.

This fixes the deploy failure caused by:
```
aws-sdk-s3 is not part of the bundle. Add it to your Gemfile. (Gem::LoadError)
```

## Notes

- The gem is set with `require: false` as Active Storage loads it on demand
- This is a follow-up fix for #73

## Related Issue

Related to #73